### PR TITLE
Tickets/pipe2D-1383-hotfix - typing hint correction

### DIFF
--- a/python/pfs/drp/qa/utils/helpers.py
+++ b/python/pfs/drp/qa/utils/helpers.py
@@ -239,10 +239,10 @@ def getTargetType(arc_data, pfsConfig) -> pd.DataFrame:
 
 
 def getFitStats(
-    arcLines: ArcLineSet,
-    detectorMap: DetectorMap,
-    selection: np.ndarray[bool],
-    numParams: int = 0):
+        arcLines: ArcLineSet,
+        detectorMap: DetectorMap,
+        selection: 'np.ndarray[bool]',
+        numParams: int = 0):
     """Gets output from calculateFitStatistics
 
     Parameters


### PR DESCRIPTION
This fixes the typing hint for `getFitStats`, which was merged despite test failure (sorry!). It also adjusts the indentation level for flake8.