### PR TITLE
Quick PIPE2D-1430 hotfix improvements.

### DIFF
--- a/python/pfs/drp/qa/detectorMapQa.py
+++ b/python/pfs/drp/qa/detectorMapQa.py
@@ -436,7 +436,7 @@ class DetectorMapQaTask(CmdLineTask, PipelineTask):
                 for datasetType, data in outputs.getDict().items():
                     if datasetType == 'dmQaDetectorStats':
                         saveFile = 'dmQA-combined-stats-{arm}{spectrograph}.csv'.format(**dataRef.dataId)
-                        data.to_csv(saveFile)
+                        data.to_csv(saveFile, index=False)
                         self.log.info(f'Combined CSV {saveFile=}')
                     if datasetType == 'dmQaResidualImage':
                         if self.plotResidual.config.combineVisits is True:

--- a/python/pfs/drp/qa/utils/helpers.py
+++ b/python/pfs/drp/qa/utils/helpers.py
@@ -293,8 +293,6 @@ def getStats(arcLinesSet, detectorMaps, dataIds):
     all_visit_stats = None
     all_detector_stats = None
 
-    # calib_frames = list()
-
     for arcLines, detectorMap, dataId in zip(arcLinesSet, detectorMaps, dataIds):
         try:
             arc_data = loadData(arcLines, detectorMap)
@@ -345,7 +343,7 @@ def getStats(arcLinesSet, detectorMaps, dataIds):
         for status_type, rows in all_arc_data.groupby(['status_type']):
             try:
                 detectorStats = pd.json_normalize(getFitStats(rows).to_dict())
-                # detectorStats['ccd'] = ccd
+                detectorStats['ccd'] = ccd
                 detectorStats['status_type'] = status_type
                 detectorStats['description'] = 'all'
                 detector_stats.append(detectorStats)
@@ -356,7 +354,7 @@ def getStats(arcLinesSet, detectorMaps, dataIds):
         for (status_type, desc), rows in all_arc_data.groupby(['status_type', 'description']):
             try:
                 detectorStats = pd.json_normalize(getFitStats(rows).to_dict())
-                # detectorStats['ccd'] = ccd
+                detectorStats['ccd'] = ccd
                 detectorStats['status_type'] = status_type
                 detectorStats['description'] = desc
                 detector_stats.append(detectorStats)


### PR DESCRIPTION
Some minor quick edits to the last merged PRs (#4, #14)

* Save the `ccd` to the detector stats table.
* Don't save the default index to the csv.