### PR TITLE
Fix 1d residual plot fiber range - tickets/PIPE2D-1431

### DIFF
--- a/python/pfs/drp/qa/utils/helpers.py
+++ b/python/pfs/drp/qa/utils/helpers.py
@@ -316,6 +316,10 @@ def getStats(arcLinesSet, detectorMaps, dataIds):
                     descriptions.remove('Trace')
 
             dmap_bbox = detectorMap.getBBox()
+            fiberIdMin = detectorMap.fiberId.min()
+            fiberIdMax = detectorMap.fiberId.max()
+            wavelengthMin = int(arcLines.wavelength.min())
+            wavelengthMax = int(arcLines.wavelength.max())
 
             for idx, rows in arc_data.groupby('status_type'):
                 visit_stat = pd.json_normalize(getFitStats(rows).to_dict())
@@ -327,6 +331,10 @@ def getStats(arcLinesSet, detectorMaps, dataIds):
                 visit_stat['description'] = ','.join(descriptions)
                 visit_stat['detector_width'] = dmap_bbox.width
                 visit_stat['detector_height'] = dmap_bbox.height
+                visit_stat['fiberId_min'] = fiberIdMin
+                visit_stat['fiberId_max'] = fiberIdMax
+                visit_stat['wavelength_min'] = wavelengthMin
+                visit_stat['wavelength_max'] = wavelengthMax
                 visit_stats.append(visit_stat)
         except NoResults:
             print(f'No results found for {dataId}')

--- a/python/pfs/drp/qa/utils/plotting.py
+++ b/python/pfs/drp/qa/utils/plotting.py
@@ -37,34 +37,35 @@ def makePlot(
         visit_stat = visit_stats.iloc[0]
         dmWidth = visit_stat.detector_width
         dmHeight = visit_stat.detector_height
+        fiberIdMin = visit_stat.fiberId_min
+        fiberIdMax = visit_stat.fiberId_max
+        wavelengthMin = visit_stat.wavelength_min
+        wavelengthMax = visit_stat.wavelength_max
     except IndexError:
         dmWidth = None
         dmHeight = None
+        fiberIdMin = None
+        fiberIdMax = None
+        wavelengthMin = None
+        wavelengthMax = None
 
     # One big fig.
     main_fig = Figure(layout='constrained', figsize=(14, 10))
 
     # Split into two rows.
     (top_fig, bottom_fig) = main_fig.subfigures(2, 1, wspace=0, height_ratios=[5, 1.5])
-    # top_fig.suptitle(
-    #     f'DetectorMap Residuals\n'
-    #     f'rerun={rerun_name}\n'
-    #     f'calib={calibDir.as_posix()}\n'
-    #     f'{arm}{spectrograph}\n'
-    #     f'{include} {calib_inputs_only=}',
-    #     weight='bold',
-    #     fontsize='small'
-    # )
+    top_fig.suptitle(
+        f'DetectorMap Residuals\n'
+        f'{arm}{spectrograph}\n',
+        weight='bold',
+        fontsize='small'
+    )
 
     # Split top fig into wo columns.
     (x_fig, y_fig) = top_fig.subfigures(1, 2, wspace=0)
 
     try:
-        pd0 = arc_data.query(
-            f'arm == "{arm}"'
-            f' and spectrograph == {spectrograph}'
-            # f' and visit {"" if calib_inputs_only else "not"} in @visit'
-        ).copy()
+        pd0 = arc_data.query(f'arm == "{arm}" and spectrograph == {spectrograph}').copy()
 
         for sub_fig, column in zip([x_fig, y_fig], ['xResid', 'yResid']):
             try:
@@ -78,8 +79,10 @@ def makePlot(
                     sigmaLines=[1.],
                     dmWidth=dmWidth,
                     dmHeight=dmHeight,
-                    # wavelengthMin=wavelengthLimits[arm][0],
-                    # wavelengthMax=wavelengthLimits[arm][1],
+                    fiberIdMin=fiberIdMin,
+                    fiberIdMax=fiberIdMax,
+                    wavelengthMin=wavelengthMin,
+                    wavelengthMax=wavelengthMax,
                     fig=sub_fig,
                 )
                 sub_fig.suptitle(f'{arm}{spectrograph}\n{column}', fontsize='small', fontweight='bold')
@@ -120,6 +123,8 @@ def plotResidual(
         useDMLayout: bool = True,
         dmWidth: int = 4096,
         dmHeight: int = 4176,
+        fiberIdMin: int = None,
+        fiberIdMax: int = None,
         wavelengthMin: float = None,
         wavelengthMax: float = None,
         fig: Figure = None
@@ -308,6 +313,9 @@ def plotResidual(
         bbox=dict(boxstyle='round', ec='k', fc='wheat'),
         fontsize='small', zorder=100
     )
+
+    if fiberIdMin is not None and fiberIdMax is not None:
+        ax0.set_xlim(fiberIdMin, fiberIdMax)
 
     if useDMLayout is True:
         # Reverse the fiber order to match the xy-pixel layout


### PR DESCRIPTION
Fixes the ranges for the "by fiber" and "by wavelength" residuals so they have the full proper range of available fibers and wavelengths.