### PR TITLE
DM residuals 2d spatial plot should only show quartz data - tickets/PIPE2D-1575

### DIFF
--- a/python/pfs/drp/qa/dmResiduals.py
+++ b/python/pfs/drp/qa/dmResiduals.py
@@ -675,6 +675,8 @@ def plot_residual(
     if column.startswith("y"):
         plotData = plotData.query("isTrace == False").copy()
         which_data = "wavelength"
+    else:
+        plotData = plotData.query("isTrace == True").copy()
 
     reserved_data = plotData.query('status == "isReserved" and isOutlier == False')
     if len(reserved_data) == 0:


### PR DESCRIPTION
* Only show the trace data on the spatial portion of the 2d plot. The statistics are correctly computed from just the quartz.