### PR TITLE
Fixing deprecation warnings from pandas - tickets/PIPE2D-1653

### DIFF
--- a/python/pfs/drp/qa/dmCombinedResiduals.py
+++ b/python/pfs/drp/qa/dmCombinedResiduals.py
@@ -174,10 +174,16 @@ def plot_detector_visits(data: DataFrame, ccd: str) -> Figure:
 
 def plot_detector_summary(stats: DataFrame) -> Figure:
     plot_data_spatial = (
-        stats.query("description == 'Trace'").filter(regex="ccd|median|weighted|soften").groupby("ccd").mean()
+        stats.query("description == 'Trace'")
+        .filter(regex="ccd|median|weighted|soften")
+        .groupby("ccd", observed=False)
+        .mean()
     )
     plot_data_wavelength = (
-        stats.query("description != 'Trace'").filter(regex="ccd|median|weighted|soften").groupby("ccd").mean()
+        stats.query("description != 'Trace'")
+        .filter(regex="ccd|median|weighted|soften")
+        .groupby("ccd", observed=False)
+        .mean()
     )
 
     fig, (ax0, ax1) = plt.subplots(ncols=2, sharey=True, layout="constrained")
@@ -356,14 +362,14 @@ def plot_dataframe(stats: DataFrame) -> Figure:
     plot_data_spatial = (
         stats.query("description == 'Trace'")
         .filter(regex="ccd|spatial.(median|weighted|soften)")
-        .groupby("ccd")
+        .groupby("ccd", observed=False)
         .mean()
     )
     plot_data_spatial.columns = [c.replace("spatial.", "") for c in plot_data_spatial.columns]
     plot_data_wavelength = (
         stats.query("description != 'Trace'")
         .filter(regex="ccd|wavelength.(median|weighted|soften)")
-        .groupby("ccd")
+        .groupby("ccd", observed=False)
         .mean()
     )
     plot_data_wavelength.columns = [c.replace("wavelength.", "") for c in plot_data_wavelength.columns]
@@ -375,9 +381,9 @@ def plot_dataframe(stats: DataFrame) -> Figure:
     ax1 = fig.add_subplot(212)
     ax0.set_axis_off()
     ax1.set_axis_off()
-    t0 = pd.plotting.table(ax0, plot_data_spatial.applymap(formatter), loc="center")
+    t0 = pd.plotting.table(ax0, plot_data_spatial.map(formatter), loc="center")
     t0.set_fontsize(16)
-    t1 = pd.plotting.table(ax1, plot_data_wavelength.applymap(formatter), loc="center")
+    t1 = pd.plotting.table(ax1, plot_data_wavelength.map(formatter), loc="center")
     t1.set_fontsize(16)
 
     ax0.set_title("Spatial (quartz only)", y=1.12)

--- a/python/pfs/drp/qa/dmResiduals.py
+++ b/python/pfs/drp/qa/dmResiduals.py
@@ -466,8 +466,8 @@ def scrub_data(
     )
 
     # Get USED and RESERVED status.
-    is_reserved = (arc_data.status & ReferenceLineStatus.DETECTORMAP_RESERVED) != 0
-    is_used = (arc_data.status & ReferenceLineStatus.DETECTORMAP_USED) != 0
+    is_reserved = (arc_data.status & ReferenceLineStatus.DETECTORMAP_RESERVED.value) != 0
+    is_used = (arc_data.status & ReferenceLineStatus.DETECTORMAP_USED.value) != 0
 
     # Make one-hot columns for status_names.
     arc_data.loc[:, "isUsed"] = is_used
@@ -970,7 +970,7 @@ def plot_residual(
         X = "fiberId"
         Y = "wavelength"
 
-    for isLine, rows in reserved_data.groupby("isLine"):
+    for isLine, rows in reserved_data.groupby("isLine", observed=False):
         im = ax2.scatter(
             rows[X],
             rows[Y],
@@ -999,9 +999,9 @@ def plot_residual(
     ax2.set_title(f"2D residual of RESERVED {which_data} data", weight="bold", fontsize="small")
 
     if bin_wl is True:
-        binned_data = plotData.dropna(subset=["wavelength", column]).groupby(["bin", "status", "isOutlier"])[
-            ["wavelength", column]
-        ]
+        binned_data = plotData.dropna(subset=["wavelength", column]).groupby(
+            ["bin", "status", "isOutlier"], observed=False
+        )[["wavelength", column]]
         plotData = binned_data.agg("median", robustRms).reset_index().sort_values("status")
 
     ax3 = scatterplot_with_outliers(


### PR DESCRIPTION
A few deprecations with the upgrade to pandas 2.2.

For the `groupby` clauses I have just added `observed=False`, which is the current default and what we have been using. The future behavior will change to `observed=True`.

`.applymap` has been changed to `.map`

Boolean logic with `Enum` flags requires using the `.value`