### PR TITLE
Add 2d residual plots to combined report - tickets/PIPE2D-1657

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ visit.
 
 | DataSet Type        | Dimensions                             | Description                                                                                 |
 |---------------------|----------------------------------------|---------------------------------------------------------------------------------------------|
+| `dmQaResidualData`  | `instrument, visit, arm, spectrograph` | Residual data for the given detector and visit.                                             | 
 | `dmQaResidualStats` | `instrument, visit, arm, spectrograph` | Summary statistics for the given detector and visit.                                        | 
 | `dmQaResidualPlot`  | `instrument, visit, arm, spectrograph` | 1D and 2D plots of the residual between the detectormap and the arclines for a given visit. |
 

--- a/python/pfs/drp/qa/dmCombinedResiduals.py
+++ b/python/pfs/drp/qa/dmCombinedResiduals.py
@@ -21,7 +21,9 @@ from lsst.pipe.base.connectionTypes import (
 from matplotlib import pyplot as plt
 from matplotlib.figure import Figure
 from pandas import DataFrame
+from pfs.drp.stella import DetectorMap
 
+from pfs.drp.qa.dmResiduals import plot_detectormap_residuals
 from pfs.drp.qa.storageClasses import MultipagePdfFigure
 from pfs.drp.qa.utils.plotting import description_palette, detector_palette
 
@@ -31,6 +33,32 @@ class DetectorMapCombinedResidualsConnections(
     dimensions=("instrument",),
 ):
     """Connections for DetectorMapCombinedQaTask"""
+
+    detectorMaps = InputConnection(
+        name="detectorMap",
+        doc="Adjusted detector mapping from fiberId,wavelength to x,y",
+        storageClass="DetectorMap",
+        dimensions=(
+            "instrument",
+            "visit",
+            "arm",
+            "spectrograph",
+        ),
+        multiple=True,
+    )
+
+    dmQaResidualData = InputConnection(
+        name="dmQaResidualData",
+        doc="DM QA residual data for plotting",
+        storageClass="DataFrame",
+        dimensions=(
+            "instrument",
+            "visit",
+            "arm",
+            "spectrograph",
+        ),
+        multiple=True,
+    )
 
     dmQaResidualStats = InputConnection(
         name="dmQaResidualStats",
@@ -91,13 +119,24 @@ class DetectorMapCombinedResidualsTask(PipelineTask):
         # Store the results.
         butlerQC.put(outputs, outputRefs)
 
-    def run(self, dmQaResidualStats: Iterable[DataFrame], run_name: str) -> Struct:
+    def run(
+        self,
+        detectorMaps: Iterable[DetectorMap],
+        dmQaResidualData: Iterable[DataFrame],
+        dmQaResidualStats: Iterable[DataFrame],
+        run_name: str,
+    ) -> Struct:
         """Create detector level stats and plots.
 
         Parameters
         ----------
+        detectorMaps : Iterable[DetectorMap]
+            An iterable of detector maps. Used for plotting metadata.
+        dmQaResidualData : Iterable[DataFrame]
+            An iterable of DataFrames containing DM QA residual data. These
+            are combined into a single DataFrame for processing.
         dmQaResidualStats : Iterable[DataFrame]
-            A an iterable of DataFrames containing DM QA residual statistics. These
+            An iterable of DataFrames containing DM QA residual statistics. These
             are combined into a single DataFrame for processing.
         run_name : str
             The name of the collection that was used for the stats.
@@ -109,6 +148,12 @@ class DetectorMapCombinedResidualsTask(PipelineTask):
         dmQaDetectorStats : `pd.DataFrame`
             Statistics of the residual analysis.
         """
+        # Put the DetectorMaps in a dict by CCD.
+        detectorMaps = {detectorMap.metadata["DETECTOR"]: detectorMap for detectorMap in detectorMaps}
+        self.log.debug(f"Visits: {[dm.getVisitInfo().id for dm in detectorMaps.values()]}")
+        self.log.debug(f"DetectorMaps: {detectorMaps.keys()}")
+
+        arc_data = pd.concat(dmQaResidualData).query('status_type == "RESERVED"')
         stats = pd.concat(dmQaResidualStats).query('status_type == "RESERVED"')
         stats.sort_values(by=["visit", "arm", "spectrograph", "description"], inplace=True)
 
@@ -120,12 +165,15 @@ class DetectorMapCombinedResidualsTask(PipelineTask):
         detector_order = [d for d in detector_order if d in stats.ccd.cat.categories]
         stats.ccd = stats.ccd.cat.reorder_categories(detector_order, ordered=True)
 
-        pdf = make_report(stats, run_name=run_name)
+        self.log.info("Making combined report")
+        pdf = make_report(stats, arc_data, detectorMaps, run_name=run_name, log=self.log)
 
         return Struct(dmQaCombinedResidualPlot=pdf, dmQaDetectorStats=stats)
 
 
-def make_report(stats: DataFrame, run_name: str) -> MultipagePdfFigure:
+def make_report(
+    stats: DataFrame, arc_data: DataFrame, detectorMaps: Iterable[DetectorMap], run_name: str, log: object
+) -> MultipagePdfFigure:
     pdf = MultipagePdfFigure()
 
     # Add the title as a figure.
@@ -135,13 +183,26 @@ def make_report(stats: DataFrame, run_name: str) -> MultipagePdfFigure:
     pdf.append(plot_dataframe(stats))
 
     # Detector summaries.
+    log.info("Making detector summary plots")
     pdf.append(plot_detector_summary(stats))
     pdf.append(plot_detector_summary_per_desc(stats))
 
     # Per visit descriptions.
     for ccd in stats.ccd.unique():
-        fig = plot_detector_visits(stats, ccd)
-        pdf.append(fig)
+        log.info(f"Making plots for {ccd}")
+        try:
+            fig = plot_detector_visits(stats, ccd)
+            pdf.append(fig)
+
+            detectorMap = detectorMaps[ccd]
+            residFig = plot_detectormap_residuals(arc_data, detectorMap)
+            residFig.suptitle("DetectorMap Residuals - {ccd}", weight="bold")
+            pdf.append(residFig)
+        except KeyError:
+            log.warning(f"DetectorMap not found for {ccd}. Skipping.")
+        except Exception as e:
+            log.warning(f"Error plotting for {ccd}: {e}")
+            continue
 
     return pdf
 

--- a/python/pfs/drp/qa/dmResiduals.py
+++ b/python/pfs/drp/qa/dmResiduals.py
@@ -300,21 +300,13 @@ def get_data_and_stats(
 
     log.info("Removing outliers")
     arc_data = arc_data.query(
-        "(isLine == True and yResidOutlier == False and xResidOutlier == False)"
-        " or "
-        "(isTrace == True and xResidOutlier == False)"
+        "(isLine == True and yResidOutlier == False) or (isTrace == True and xResidOutlier == False)"
     ).copy()
 
     descriptions = sorted(list(arc_data.description.unique()))
     with suppress(ValueError):
         if len(descriptions) > 1:
             descriptions.remove("Trace")
-
-    dmap_bbox = detectorMap.getBBox()
-    fiberIdMin = detectorMap.fiberId.min()
-    fiberIdMax = detectorMap.fiberId.max()
-    wavelengthMin = int(arcLines.wavelength.min())
-    wavelengthMax = int(arcLines.wavelength.max())
 
     arc_data["arm"] = dataId["arm"]
     arc_data["spectrograph"] = dataId["spectrograph"]
@@ -330,12 +322,6 @@ def get_data_and_stats(
         visit_stats["visit"] = dataId["visit"]
         visit_stats["ccd"] = "{arm}{spectrograph}".format(**dataId)
         visit_stats["description"] = ",".join(descriptions)
-        visit_stats["detector_width"] = dmap_bbox.width
-        visit_stats["detector_height"] = dmap_bbox.height
-        visit_stats["fiberId_min"] = fiberIdMin
-        visit_stats["fiberId_max"] = fiberIdMax
-        visit_stats["wavelength_min"] = wavelengthMin
-        visit_stats["wavelength_max"] = wavelengthMax
         stats.append(visit_stats)
 
     stats = pd.concat(stats)

--- a/python/pfs/drp/qa/dmResiduals.py
+++ b/python/pfs/drp/qa/dmResiduals.py
@@ -850,7 +850,8 @@ def plot_residual(
         ymax=dataRange,
         palette=pal,
         ax=ax0,
-        refline=0,
+        refline=[0],
+        rasterized=True,
     )
 
     def drawRefLines(ax, goodRange, sigmaRange, isVertical=False):
@@ -983,6 +984,7 @@ def plot_residual(
             s=2,
             marker="d" if isLine else ".",
             zorder=100 if isLine else 0,
+            rasterized=True,
         )
 
     fig.colorbar(
@@ -1016,9 +1018,9 @@ def plot_residual(
         ymax=dataRange,
         palette=pal,
         ax=ax3,
-        refline=0.0,
+        refline=[0.0],
         vertical=True,
-        rasterized=True if not bin_wl else False,
+        rasterized=True,
     )
     try:
         ax3.get_legend().set_visible(False)


### PR DESCRIPTION
This adds the 2D residual back to the report, immediately following the individual visit report.  

Work needs ot be done to reduce the file size and optimize/smooth the final result.

This PR changes it so that the individual `dmResidual` task now saves the scrubbed and analyzed `lines.data`. This adds a new output at the individual visit level, `dmQaResidualData`.

The combined report then concats the `dmQaResidualData` and produces plots.  This follows the other tasks wherein the `dmCombinedResidual` merely does analysis on already processed data (by the `dmResidual` task).

This involves some abstraction of some of the functions in `dmResidual` task to make them work with `dmCombinedResidual`.