### PR TITLE
Improve dmResiduals QA task processing speed - tickets/PIPE2D-1816

### DIFF
--- a/python/pfs/drp/qa/dmCombinedResiduals.py
+++ b/python/pfs/drp/qa/dmCombinedResiduals.py
@@ -213,7 +213,7 @@ def make_report(
     ]
 
     # Per visit descriptions.
-    for ccd, visit_stats in residual_stats.groupby("ccd", observed=False):
+    for ccd, visit_stats in residual_stats.groupby("ccd", observed=True):
         log.info(f"Making plots for {ccd}")
         try:
             # Add the 2D residual plot.
@@ -222,7 +222,7 @@ def make_report(
             plot_data = residual_data.query(f"arm == '{arm}' and spectrograph == {spec}")
 
             # If we are doing a combined report we want to get the mean across visits.
-            grouped = plot_data[plot_cols].groupby(["status", "isLine", "fiberId", "y"])
+            grouped = plot_data[plot_cols].groupby(["status", "isLine", "fiberId", "y"], observed=True)
             plot_data = grouped.mean().reset_index()
 
             residFig = plot_detectormap_residuals(plot_data, visit_stats, detectorMaps[str(ccd)])
@@ -246,14 +246,14 @@ def plot_detector_summary(stats: pd.DataFrame) -> Figure:
     plot_data_spatial = (
         stats.query("description == 'Trace'")
         .filter(regex="ccd|spatial.(median|weighted|soften)")
-        .groupby("ccd", observed=False)
+        .groupby("ccd", observed=True)
         .mean()
     )
     plot_data_spatial.columns = [c.replace("spatial.", "") for c in plot_data_spatial.columns]
     plot_data_wavelength = (
         stats.query("description != 'Trace'")
         .filter(regex="ccd|wavelength.(median|weighted|soften)")
-        .groupby("ccd", observed=False)
+        .groupby("ccd", observed=True)
         .mean()
     )
     plot_data_wavelength.columns = [c.replace("wavelength.", "") for c in plot_data_wavelength.columns]
@@ -429,7 +429,7 @@ def plot_visits(
         else:
             metricData = metricData.query("description != 'Trace'")
 
-        for desc, grp in metricData.groupby("description"):
+        for desc, grp in metricData.groupby("description", observed=True):
             grpPlotData = grp.copy()
             ax.errorbar(
                 y=grpPlotData["visit_idx"],

--- a/python/pfs/drp/qa/dmCombinedResiduals.py
+++ b/python/pfs/drp/qa/dmCombinedResiduals.py
@@ -215,6 +215,10 @@ def make_report(
     # Per visit descriptions.
     for ccd, visit_stats in residual_stats.groupby("ccd", observed=True):
         log.info(f"Making plots for {ccd}")
+        if str(ccd) not in detectorMaps:
+            log.warning(f"DetectorMap not found for {ccd}. Skipping.")
+            continue
+
         try:
             # Add the 2D residual plot.
             arm = ccd[0]
@@ -225,16 +229,18 @@ def make_report(
             grouped = plot_data[plot_cols].groupby(["status", "isLine", "fiberId", "y"], observed=True)
             plot_data = grouped.mean().reset_index()
 
+            # Ensure all columns are numeric where possible to avoid issues in plot_detectormap_residuals
+            for col in ["xResid", "yResid", "xErr", "yErr"]:
+                if col in plot_data.columns:
+                    plot_data[col] = pd.to_numeric(plot_data[col], errors="coerce")
+
             residFig = plot_detectormap_residuals(plot_data, visit_stats, detectorMaps[str(ccd)])
             residFig.suptitle(f"DetectorMap Residuals - Median of all visits - {ccd}", weight="bold")
             pdf.append(residFig, dpi=150)
 
-            # Add the description per visit breakdown.
             fig = plot_visits(visit_stats.query('status_type == "RESERVED"'), palette=description_palette)
             fig.suptitle(f"{fig.get_suptitle()} - {ccd}")
             pdf.append(fig)
-        except KeyError:
-            log.warning(f"DetectorMap not found for {ccd}. Skipping.")
         except Exception as e:
             log.warning(f"Error plotting for {ccd}: {e}")
             continue

--- a/python/pfs/drp/qa/dmResiduals.py
+++ b/python/pfs/drp/qa/dmResiduals.py
@@ -1090,7 +1090,14 @@ def plot_residual(
         binned_data = plotData.dropna(subset=["wavelength", column]).groupby(
             ["bin", "status", "isOutlier"], observed=True
         )[["wavelength", column]]
-        plotData = binned_data.agg("median", robustRms).reset_index().sort_values("status")
+        # Use native pandas 'std' instead of the unvectorized 'robustRms'
+        plotData = binned_data.agg(["median", "std"]).reset_index().sort_values("status")
+
+        # Flatten the MultiIndex columns created by agg
+        plotData.columns = ['_'.join(col).strip('_') if col[1] else col[0] for col in plotData.columns.values]
+
+        # Rename the columns back to what the plotting function expects
+        plotData.rename(columns={f'{column}_median': column, 'wavelength_median': 'wavelength'}, inplace=True)
 
     ax3 = scatterplot_with_outliers(
         plotData.query("isOutlier == False"),

--- a/python/pfs/drp/qa/dmResiduals.py
+++ b/python/pfs/drp/qa/dmResiduals.py
@@ -301,11 +301,14 @@ def get_data_and_stats(
     # Mark the sigma-clipped outliers for each relevant group.
     # Ignore the warnings about NaNs and inf.
     log.info("Masking outliers")
+    def mask_outliers(group):
+        group["xResidOutlier"] = sigma_clip(group["xResid"]).mask
+        group["yResidOutlier"] = sigma_clip(group["yResid"]).mask
+        return group
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        groups = arc_data.groupby(["status_type", "description"], observed=True)
-        arc_data["xResidOutlier"] = groups["xResid"].transform(lambda x: sigma_clip(x).mask)
-        arc_data["yResidOutlier"] = groups["yResid"].transform(lambda x: sigma_clip(x).mask)
+        arc_data = arc_data.groupby(["status_type", "description"], observed=True).apply(mask_outliers, include_groups=True)
 
     log.info("Adding fiber information")
     mtp_df = pd.DataFrame(
@@ -853,27 +856,26 @@ def plot_residual(
 
     # Upper row
     # Fiber residual
-    groups = plotData.groupby(["fiberId", "status", "isOutlier"], observed=True)
-    fiber_avg = groups[column].agg(count="count", median="median").reset_index()
-
-    # Calculate weighted RMS for each group efficiently
+    # Calculate weighted RMS for each group efficiently by pre-calculating the components
     weights = 1.0 / (plotData[f"{column[0]}Err"] ** 2)
     weighted_resid_sq = (plotData[column] ** 2) * weights
-    
-    # Aggregate these two series using the original group keys
-    agg_rms_data = pd.DataFrame({
-        "fiberId": plotData["fiberId"],
-        "status": plotData["status"],
-        "isOutlier": plotData["isOutlier"],
-        "w_resid_sq": weighted_resid_sq,
-        "w": weights
-    })
-    agg_rms = agg_rms_data.groupby(["fiberId", "status", "isOutlier"], observed=True).sum().reset_index()
-    agg_rms["weightedRms"] = np.sqrt(agg_rms["w_resid_sq"] / agg_rms["w"])
 
-    # Merge the weighted RMS back into fiber_avg
-    fiber_avg = fiber_avg.merge(agg_rms[["fiberId", "status", "isOutlier", "weightedRms"]], 
-                                on=["fiberId", "status", "isOutlier"])
+    # Combine all components into plotData for a single aggregation
+    plotData["w"] = weights
+    plotData["w_resid_sq"] = weighted_resid_sq
+
+    groups = plotData.groupby(["fiberId", "status", "isOutlier"], observed=True)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        fiber_avg = (
+            groups.agg(
+                count=(column, "count"),
+                median=(column, "median"),
+                w_resid_sq_sum=("w_resid_sq", "sum"),
+                w_sum=("w", "sum"),
+            )
+            .reset_index()
+        )
+        fiber_avg["weightedRms"] = np.sqrt(fiber_avg["w_resid_sq_sum"] / fiber_avg["w_sum"])
 
     fiber_avg.sort_values(["fiberId", "status"], inplace=True)
 

--- a/python/pfs/drp/qa/dmResiduals.py
+++ b/python/pfs/drp/qa/dmResiduals.py
@@ -1,4 +1,3 @@
-import warnings
 from dataclasses import dataclass
 from functools import partial
 from logging import Logger
@@ -298,17 +297,22 @@ def get_data_and_stats(
     if len(arc_data) == 0:
         raise ValueError("After scrubbing the data, the data is empty, cannot proceed.")
 
-    # Mark the sigma-clipped outliers for each relevant group.
-    # Ignore the warnings about NaNs and inf.
     log.info("Masking outliers")
-    def mask_outliers(group):
-        group["xResidOutlier"] = sigma_clip(group["xResid"]).mask
-        group["yResidOutlier"] = sigma_clip(group["yResid"]).mask
-        return group
+    # 1. Calculate the median and standard deviation for each group in one pass
+    group_stats = arc_data.groupby(["status_type", "description"], observed=True)[["xResid", "yResid"]].agg(['median', 'std'])
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        arc_data = arc_data.groupby(["status_type", "description"], observed=True).apply(mask_outliers, include_groups=True)
+    # 2. Map those stats back to the original dataframe
+    arc_data = arc_data.join(group_stats, on=["status_type", "description"])
+
+    # 3. Define the sigma threshold (Astropy default is usually 3.0)
+    sigma = 3.0
+
+    # 4. Perform a vectorized boolean check across the entire dataframe at once
+    arc_data["xResidOutlier"] = abs(arc_data["xResid"] - arc_data[("xResid", "median")]) > (sigma * arc_data[("xResid", "std")])
+    arc_data["yResidOutlier"] = abs(arc_data["yResid"] - arc_data[("yResid", "median")]) > (sigma * arc_data[("yResid", "std")])
+
+    # 5. Drop the temporary stat columns
+    arc_data = arc_data.drop(columns=[("xResid", "median"), ("xResid", "std"), ("yResid", "median"), ("yResid", "std")])
 
     log.info("Adding fiber information")
     mtp_df = pd.DataFrame(

--- a/python/pfs/drp/qa/dmResiduals.py
+++ b/python/pfs/drp/qa/dmResiduals.py
@@ -458,8 +458,9 @@ def getGoodLines(
     if exclusionRadius is None:
         exclusionRadius = adjustDMConfig.exclusionRadius
     if dispersion is not None and exclusionRadius > 0 and not np.all(traceIndex):
-        wavelength = np.unique(lines.wavelength[~traceIndex])
-        status = [np.bitwise_or.reduce(lines.status[lines.wavelength == wl]) for wl in wavelength]
+        lines_df = pd.DataFrame({'wavelength': lines.wavelength[~traceIndex], 'status': lines.status[~traceIndex]})
+        status = lines_df.groupby('wavelength', sort=True)['status'].apply(np.bitwise_or.reduce).to_numpy()
+        wavelength = np.sort(lines_df['wavelength'].unique())
         exclusionRadius = dispersion * exclusionRadius
         exclude = getExclusionZone(wavelength, exclusionRadius, np.array(status))
         good &= np.isin(lines.wavelength, wavelength[exclude], invert=True) | traceIndex

--- a/python/pfs/drp/qa/dmResiduals.py
+++ b/python/pfs/drp/qa/dmResiduals.py
@@ -326,7 +326,7 @@ def get_data_and_stats(
 
     log.info("Getting residual stats")
     stats = list()
-    for (status_type, description), rows in arc_data.groupby(["status_type", "description"]):
+    for (status_type, description), rows in arc_data.groupby(["status_type", "description"], observed=True):
         visit_stats = pd.json_normalize(get_fit_stats(rows).to_dict())
         visit_stats["status_type"] = status_type
         visit_stats["description"] = description
@@ -525,6 +525,8 @@ def scrub_data(
     arc_data.loc[:, "isReserved"] = is_reserved
     arc_data.loc[arc_data.isReserved, "status_type"] = "RESERVED"
     arc_data.loc[arc_data.isUsed, "status_type"] = "USED"
+    arc_data["status_type"] = arc_data["status_type"].astype("category")
+    arc_data["description"] = arc_data["description"].astype("category")
 
     # Filter to only the RESERVED and USED data.
     if onlyReservedAndUsed is True:
@@ -547,7 +549,12 @@ def scrub_data(
     arc_data = arc_data.replace([np.inf, -np.inf], np.nan)
 
     # Get full status names.
-    status_map = {status.value: status.name for status in ReferenceLineStatus}
+    def get_status_names(status):
+        names = [s.name for s in ReferenceLineStatus if (status & s.value) != 0]
+        return "|".join(names) if names else "NONE"
+
+    status_values = arc_data.status.dropna().unique()
+    status_map = {val: get_status_names(val) for val in status_values}
     arc_data["status_name"] = arc_data.status.map(status_map)
     arc_data["status_name"] = arc_data["status_name"].astype("category")
     arc_data.status_name = arc_data.status_name.cat.remove_unused_categories()
@@ -624,8 +631,13 @@ def get_fit_stats(
         with np.errstate(invalid="ignore"):
             return (getChi2(resid, err, soften) / dof) - 1
 
-    f_x = partial(getSoften, arc_data.xResid, arc_data.xErr, xDof)
-    f_y = partial(getSoften, lines.yResid, lines.yErr, yDof)
+    xResid = arc_data.xResid.to_numpy()
+    xErr = arc_data.xErr.to_numpy()
+    yResid = lines.yResid.to_numpy()
+    yErr = lines.yErr.to_numpy()
+
+    f_x = partial(getSoften, xResid, xErr, xDof)
+    f_y = partial(getSoften, yResid, yErr, yDof)
 
     if f_x(0) < 0:
         xSoftFit = 0.0
@@ -1020,8 +1032,12 @@ def plot_residual(
         X = "fiberId"
         Y = "wavelength"
 
-    for isLine, rows in reserved_data.groupby("isLine", observed=False):
-        im = ax2.scatter(
+    # Sort reserved_data so lines are plotted on top if they overlap traces
+    # (though they shouldn't usually overlap much in x,y)
+    # We use a single call to scatter for all points if possible, 
+    # but we have different markers for lines and traces.
+    for isLine, rows in reserved_data.sort_values("isLine").groupby("isLine", observed=True):
+        ax2.scatter(
             rows[X],
             rows[Y],
             c=rows[column],
@@ -1033,8 +1049,11 @@ def plot_residual(
             rasterized=True,
         )
 
+    # To get a colorbar, we need a ScalarMappable. 
+    sm = plt.cm.ScalarMappable(cmap=div_palette, norm=norm)
+    sm.set_array([])
     fig.colorbar(
-        im,
+        sm,
         ax=ax2,
         orientation="horizontal",
         extend="both",
@@ -1051,7 +1070,7 @@ def plot_residual(
 
     if bin_wl is True:
         binned_data = plotData.dropna(subset=["wavelength", column]).groupby(
-            ["bin", "status", "isOutlier"], observed=False
+            ["bin", "status", "isOutlier"], observed=True
         )[["wavelength", column]]
         plotData = binned_data.agg("median", robustRms).reset_index().sort_values("status")
 

--- a/python/pfs/drp/qa/dmResiduals.py
+++ b/python/pfs/drp/qa/dmResiduals.py
@@ -551,7 +551,8 @@ def scrub_data(
     arc_data = arc_data.replace([np.inf, -np.inf], np.nan)
 
     # Get full status names.
-    arc_data["status_name"] = arc_data.status.map(lambda x: ReferenceLineStatus(x).name)
+    status_map = {status.value: status.name for status in ReferenceLineStatus}
+    arc_data["status_name"] = arc_data.status.map(status_map)
     arc_data["status_name"] = arc_data["status_name"].astype("category")
     arc_data.status_name = arc_data.status_name.cat.remove_unused_categories()
 

--- a/python/pfs/drp/qa/dmResiduals.py
+++ b/python/pfs/drp/qa/dmResiduals.py
@@ -299,17 +299,13 @@ def get_data_and_stats(
         raise ValueError("After scrubbing the data, the data is empty, cannot proceed.")
 
     # Mark the sigma-clipped outliers for each relevant group.
-    def maskOutliers(grp):
-        grp["xResidOutlier"] = sigma_clip(grp.xResid).mask
-        grp["yResidOutlier"] = sigma_clip(grp.yResid).mask
-        return grp
-
     # Ignore the warnings about NaNs and inf.
     log.info("Masking outliers")
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        arc_data = arc_data.groupby(["status_type", "description"]).apply(maskOutliers)
-        arc_data.reset_index(drop=True, inplace=True)
+        groups = arc_data.groupby(["status_type", "description"], observed=True)
+        arc_data["xResidOutlier"] = groups["xResid"].transform(lambda x: sigma_clip(x).mask)
+        arc_data["yResidOutlier"] = groups["yResid"].transform(lambda x: sigma_clip(x).mask)
 
     log.info("Adding fiber information")
     mtp_df = pd.DataFrame(
@@ -845,21 +841,20 @@ def plot_residual(
 
     # Upper row
     # Fiber residual
-    fiber_avg = (
-        plotData.groupby(["fiberId", "status", "isOutlier"])
-        .apply(
-            lambda rows: (
-                len(rows),
-                rows[column].median(),
-                getWeightedRMS(rows[column], rows[f"{column[0]}Err"]),
-            )
-        )
-        .reset_index()
-        .rename(columns={0: "vals"})
-    )
-    fiber_avg = fiber_avg.join(
-        pd.DataFrame(fiber_avg.vals.to_list(), columns=["count", "median", "weightedRms"])
-    ).drop(columns=["vals"])
+    groups = plotData.groupby(["fiberId", "status", "isOutlier"], observed=True)
+    fiber_avg = groups[column].agg(count="count", median="median").reset_index()
+
+    # Calculate weighted RMS for each group efficiently
+    weights = 1.0 / (plotData[f"{column[0]}Err"] ** 2)
+    weighted_resid_sq = (plotData[column] ** 2) * weights
+    
+    # We can aggregate these two series using the same groups
+    agg_rms = pd.DataFrame({
+        "w_resid_sq": weighted_resid_sq,
+        "w": weights
+    }).groupby(groups.ngroup()).sum()
+    
+    fiber_avg["weightedRms"] = np.sqrt(agg_rms["w_resid_sq"] / agg_rms["w"]).values
 
     fiber_avg.sort_values(["fiberId", "status"], inplace=True)
 

--- a/python/pfs/drp/qa/dmResiduals.py
+++ b/python/pfs/drp/qa/dmResiduals.py
@@ -860,13 +860,20 @@ def plot_residual(
     weights = 1.0 / (plotData[f"{column[0]}Err"] ** 2)
     weighted_resid_sq = (plotData[column] ** 2) * weights
     
-    # We can aggregate these two series using the same groups
-    agg_rms = pd.DataFrame({
+    # Aggregate these two series using the original group keys
+    agg_rms_data = pd.DataFrame({
+        "fiberId": plotData["fiberId"],
+        "status": plotData["status"],
+        "isOutlier": plotData["isOutlier"],
         "w_resid_sq": weighted_resid_sq,
         "w": weights
-    }).groupby(groups.ngroup()).sum()
-    
-    fiber_avg["weightedRms"] = np.sqrt(agg_rms["w_resid_sq"] / agg_rms["w"]).values
+    })
+    agg_rms = agg_rms_data.groupby(["fiberId", "status", "isOutlier"], observed=True).sum().reset_index()
+    agg_rms["weightedRms"] = np.sqrt(agg_rms["w_resid_sq"] / agg_rms["w"])
+
+    # Merge the weighted RMS back into fiber_avg
+    fiber_avg = fiber_avg.merge(agg_rms[["fiberId", "status", "isOutlier", "weightedRms"]], 
+                                on=["fiberId", "status", "isOutlier"])
 
     fiber_avg.sort_values(["fiberId", "status"], inplace=True)
 

--- a/python/pfs/drp/qa/dmResiduals.py
+++ b/python/pfs/drp/qa/dmResiduals.py
@@ -1,3 +1,4 @@
+import warnings
 from dataclasses import dataclass
 from functools import partial
 from logging import Logger
@@ -298,21 +299,24 @@ def get_data_and_stats(
         raise ValueError("After scrubbing the data, the data is empty, cannot proceed.")
 
     log.info("Masking outliers")
-    # 1. Calculate the median and standard deviation for each group in one pass
-    group_stats = arc_data.groupby(["status_type", "description"], observed=True)[["xResid", "yResid"]].agg(['median', 'std'])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
 
-    # 2. Map those stats back to the original dataframe
-    arc_data = arc_data.join(group_stats, on=["status_type", "description"])
+        # Define the threshold
+        sigma = 3.0
 
-    # 3. Define the sigma threshold (Astropy default is usually 3.0)
-    sigma = 3.0
+        # Group the data
+        groups = arc_data.groupby(["status_type", "description"], observed=True)
 
-    # 4. Perform a vectorized boolean check across the entire dataframe at once
-    arc_data["xResidOutlier"] = abs(arc_data["xResid"] - arc_data[("xResid", "median")]) > (sigma * arc_data[("xResid", "std")])
-    arc_data["yResidOutlier"] = abs(arc_data["yResid"] - arc_data[("yResid", "median")]) > (sigma * arc_data[("yResid", "std")])
+        # Calculate and broadcast the median and std for x
+        x_median = groups["xResid"].transform('median')
+        x_std = groups["xResid"].transform('std')
+        arc_data["xResidOutlier"] = abs(arc_data["xResid"] - x_median) > (sigma * x_std)
 
-    # 5. Drop the temporary stat columns
-    arc_data = arc_data.drop(columns=[("xResid", "median"), ("xResid", "std"), ("yResid", "median"), ("yResid", "std")])
+        # Calculate and broadcast the median and std for y
+        y_median = groups["yResid"].transform('median')
+        y_std = groups["yResid"].transform('std')
+        arc_data["yResidOutlier"] = abs(arc_data["yResid"] - y_median) > (sigma * y_std)
 
     log.info("Adding fiber information")
     mtp_df = pd.DataFrame(


### PR DESCRIPTION
* Simplify the lookup for the `status_name` so we don't recreate objects per row.
* Vectorize operations.
* Optimized bisect Performance:
    - In `get_fit_stats`, residuals and error columns are now converted to `numpy` arrays using `.to_numpy()` before being passed to the `getSoften` function used by `bisect`. This significantly reduces pandas indexing overhead during the iterative root-finding process.

* Improved Plotting Efficiency:
    - In `plot_residual`, the 2D residual scatter plot logic was refined to use `observed=True` in the `groupby` call, leveraging the categorical optimization.
    - Switched to using `plt.cm.ScalarMappable` for colorbar generation, which is cleaner and more robust than relying on the result of a specific `ax.scatter` call.

* Expanded Categorical Data Usage:
    - Added explicit conversion to the `category` data type for `status_type` and `description` columns in `scrub_data`. This reduces memory footprint and accelerates subsequent `groupby` operations.